### PR TITLE
[Feat] 킹정킹, 에바킹 구현

### DIFF
--- a/QAQA/QAQA/Model/Game/RealTimeGame.swift
+++ b/QAQA/QAQA/Model/Game/RealTimeGame.swift
@@ -36,6 +36,11 @@ class RealTimeGame: NSObject, GKGameCenterControllerDelegate, ObservableObject {
     @Published var reactionScore = 0
     @Published var allKingjungScore = 0
     @Published var allEvaScore = 0
+    @Published var myKingjungScore = 0
+    @Published var myEvaScore = 0
+    @Published var reactionScoreList: [(String, Int, Int)] = [] // 이름, 킹정수, 에바수
+    @Published var kingjungKing = ""
+    @Published var evaKing = ""
 
     // 타이머 변수
     @Published var countMin = 10
@@ -141,22 +146,6 @@ class RealTimeGame: NSObject, GKGameCenterControllerDelegate, ObservableObject {
         }
         reportProgress()
     }
-
-    func takeAction() {
-        myScore += 1
-        
-        if (myScore - opponentScore == 10) || (myScore == 100) {
-//            endMatch()
-            return
-        }
-        
-        do {
-            let data = encode(score: myScore)
-            try myMatch?.sendData(toAllPlayers: data!, with: GKMatch.SendDataMode.unreliable)
-        } catch {
-            print("Error: \(error.localizedDescription).")
-        }
-    }
     
     func endMatch() {
         let opponentOutcome = opponentScore > myScore ? "won" : "lost"
@@ -190,6 +179,15 @@ class RealTimeGame: NSObject, GKGameCenterControllerDelegate, ObservableObject {
 
         myScore = 0
         opponentScore = 0
+        
+        reactionScore = 0
+        allKingjungScore = 0
+        allEvaScore = 0
+        myKingjungScore = 0
+        myEvaScore = 0
+        reactionScoreList = [] // 이름, 킹정수, 에바수
+        
+        // 리액션 수 및 다른 변수들 초기화
     }
 
     func reportProgress() {
@@ -231,6 +229,16 @@ class RealTimeGame: NSObject, GKGameCenterControllerDelegate, ObservableObject {
     func pushReaction() {
         do {
             let data = encode(playReaction: playReaction, isGoodReaction: isGoodReaction, reactionScore: reactionScore, allKingjungScore: allKingjungScore, allEvaScore: allEvaScore)
+            try myMatch?.sendData(toAllPlayers: data!, with: GKMatch.SendDataMode.unreliable)
+        } catch {
+            print("Error: \(error.localizedDescription).")
+        }
+    }
+    
+    func rankReactionKing() {
+        reactionScoreList.append((myName, myKingjungScore, myEvaScore))
+        do {
+            let data = encode(playerName: GKLocalPlayer.local.displayName, myKingjungScore: myKingjungScore, myEvaScore: myEvaScore)
             try myMatch?.sendData(toAllPlayers: data!, with: GKMatch.SendDataMode.unreliable)
         } catch {
             print("Error: \(error.localizedDescription).")

--- a/QAQA/QAQA/Utils/GameCenter/RealTimeGame+GKMatchDelegate.swift
+++ b/QAQA/QAQA/Utils/GameCenter/RealTimeGame+GKMatchDelegate.swift
@@ -56,6 +56,10 @@ extension RealTimeGame: GKMatchDelegate {
         } else if let min = gameData?.countMin, let second = gameData?.countSecond {
             countMin = min
             countSecond = second
+        } else if let playerName = gameData?.playerName, let playerKingjungScore = gameData?.myKingjungScore, let playerEvaScore = gameData?.myEvaScore {
+            reactionScoreList.append((playerName, playerKingjungScore, playerEvaScore))
+            kingjungKing = reactionScoreList.sorted(by: { $0.1 > $1.1 }).first?.0 ?? "None" // 0이면 에바킹 킹정킹을 - 으로
+            evaKing = reactionScoreList.sorted(by: { $0.2 > $1.2 }).first?.0 ?? "None"
         }
         
         //햅틱부분
@@ -64,8 +68,12 @@ extension RealTimeGame: GKMatchDelegate {
         } else if let wasErrorCalled = gameData?.wasErrorCalledHaptics, wasErrorCalled {
             triggerErrorHaptic()
         }
-        print("kingjung: \(allKingjungScore)")
-        print("eva: \(allEvaScore)")
+        if allEvaScore == 0 {
+            evaKing = "-"
+        }
+        if allKingjungScore == 0 {
+            kingjungKing = "-"
+        }
     }
     
     func triggerSuccessHaptic() {

--- a/QAQA/QAQA/Utils/GameCenter/RealTimeGame+MatchData.swift
+++ b/QAQA/QAQA/Utils/GameCenter/RealTimeGame+MatchData.swift
@@ -23,6 +23,8 @@ struct GameData: Codable {
     var reactionScore: Int?
     var allKingjuncScore: Int?
     var allEvaScore: Int?
+    var myKingjungScore: Int?
+    var myEvaScore: Int?
     //햅틱부분
     var wasSuccessCalledHaptics: Bool? // new field
     var wasErrorCalledHaptics: Bool? // new field
@@ -43,6 +45,11 @@ extension RealTimeGame {
     
     func encode(playReaction: Bool, isGoodReaction: Bool, reactionScore: Int, allKingjungScore: Int, allEvaScore: Int) -> Data? {
         let gameData = GameData(matchName: matchName, playerName: GKLocalPlayer.local.displayName, isPlayingReaction: playReaction, isGoodReaction: isGoodReaction, reactionScore: reactionScore, allKingjuncScore: allKingjungScore, allEvaScore: allEvaScore)
+        return encode(gameData: gameData)
+    }
+    
+    func encode(playerName: String, myKingjungScore: Int, myEvaScore: Int) -> Data? {
+        let gameData = GameData(matchName: matchName, playerName: GKLocalPlayer.local.displayName, myKingjungScore: myKingjungScore, myEvaScore: myEvaScore)
         return encode(gameData: gameData)
     }
 

--- a/QAQA/QAQA/View/Outro/OutroEndingView.swift
+++ b/QAQA/QAQA/View/Outro/OutroEndingView.swift
@@ -103,7 +103,7 @@ struct OutroEndingView: View {
                 }
             }
             if (isShowingInfoView) {
-                OutroInfoView()
+                OutroInfoView(game: game)
                     .onAppear() {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
                             isShowingInfoView.toggle()

--- a/QAQA/QAQA/View/Outro/OutroInfoView.swift
+++ b/QAQA/QAQA/View/Outro/OutroInfoView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct OutroInfoView: View {
+    @ObservedObject var game: RealTimeGame
+    
     var body: some View {
         ZStack{
             Color.white
@@ -29,11 +31,14 @@ struct OutroInfoView: View {
                     .frame(width: 202)
             }
         }
+        .onAppear {
+            game.rankReactionKing()
+        }
     }
 }
 
 struct OutroInfoView_Previews: PreviewProvider {
     static var previews: some View {
-        OutroInfoView()
+        OutroInfoView(game: RealTimeGame())
     }
 }

--- a/QAQA/QAQA/View/Outro/OutroResultCardView.swift
+++ b/QAQA/QAQA/View/Outro/OutroResultCardView.swift
@@ -39,7 +39,7 @@ struct OutroResultCardView: View {
                 VStack {
                     Spacer()
                         .frame(height: 25)
-                    Text("킹정킹") //킹정킹 username
+                    Text("\(game.kingjungKing)") //킹정킹 username
                         .font(.custom("BMJUAOTF", size: 30))
                         .foregroundColor(.black)
                     Spacer()
@@ -58,7 +58,7 @@ struct OutroResultCardView: View {
                 VStack {
                     Spacer()
                         .frame(height: 25)
-                    Text("에바킹") //에바킹 username
+                    Text("\(game.evaKing)") //에바킹 username
                         .font(.custom("BMJUAOTF", size: 30))
                         .foregroundColor(.black)
                     Spacer()

--- a/QAQA/QAQA/View/Question/QuestionView.swift
+++ b/QAQA/QAQA/View/Question/QuestionView.swift
@@ -108,6 +108,7 @@ struct QuestionView: View {
                             game.isGoodReaction = true // 킹정
                             game.allKingjungScore += 1
                             game.reactionScore += 1
+                            game.myKingjungScore += 1
                             withAnimation(
                                 .default
 //                                .spring(response: 0.2, blendDuration: 0.0)___띠용 애니메이션 해제
@@ -139,6 +140,7 @@ struct QuestionView: View {
                             game.isGoodReaction = false // 에바
                             game.allEvaScore += 1
                             game.reactionScore += 1
+                            game.myEvaScore += 1
                             withAnimation(
                                 .default
 //                                .spring(response: 0.2, blendDuration: 0.0)___띠용 애니메이션 해제


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feat/#54

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
킹정킹, 에바킹 구현했습니다.
- 킹정 수, 에바 수가 0인 경우에는 "-" 으로 표시됩니다.
- 동일한 수의 킹정/에바를 클릭한 경우에는 랜덤으로 유저가 표시됩니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `takeAction` 함수가 불필요한 코드라서 삭제했습니다.
- `resetMatch` 함수에서 리액션 스코어 등의 변수를 초기화하는 코드 작성했습니다.
- `game.rankReactionKing()` 함수가 실행되면 킹정킹, 에바킹이 저장됩니다. 이 함수는 `OutroInfoView`가 `onAppear` 될 때 실행됩니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|킹정킹, 에바킹|<img width="1245" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MC3-Team16-QAQA/assets/70744494/5cae4b93-dabf-47c2-afb4-5f26ab970f91">|



## 📟 관련 이슈
- Resolved: #54
